### PR TITLE
Update URL for LUISA land cover basemap

### DIFF
--- a/01_Coastal_flooding/Risk_assessment_FLOOD_COASTAL.ipynb
+++ b/01_Coastal_flooding/Risk_assessment_FLOOD_COASTAL.ipynb
@@ -799,7 +799,7 @@
     "# Check if land use dataset has not yet been downloaded\n",
     "if  not os.path.isfile(os.path.join(data_general_dir,luisa_filename)):\n",
     "    # , define the URL for the LUISA basemap and download it\n",
-    "    url = f'http://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/LUISA/EUROPE/Basemaps/2018/VER2021-03-24/{luisa_filename}'\n",
+    "    url = f'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/LUISA/EUROPE/Basemaps/LandUse/2018/LATEST/{luisa_filename}'\n",
     "    pooch.retrieve(\n",
     "        url=url,\n",
     "        known_hash=None,  # Hash value is not provided\n",

--- a/02_River_flooding/Risk_assessment_FLOOD_RIVER.ipynb
+++ b/02_River_flooding/Risk_assessment_FLOOD_RIVER.ipynb
@@ -929,7 +929,7 @@
     "# Check if land use dataset has not yet been downloaded\n",
     "if  not os.path.isfile(os.path.join(data_general_dir,luisa_filename)):\n",
     "    # , define the URL for the LUISA basemap and download it\n",
-    "    url = f'http://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/LUISA/EUROPE/Basemaps/2018/VER2021-03-24/{luisa_filename}'\n",
+    "    url = f'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/LUISA/EUROPE/Basemaps/LandUse/2018/LATEST/{luisa_filename}'\n",
     "    pooch.retrieve(\n",
     "        url=url,\n",
     "        known_hash=None,  # Hash value is not provided\n",


### PR DESCRIPTION
Our dataset availability tests have been failing for LUISA recently. Could be that JRC requires https now as that fixes it.

- use https
- use file from `LATEST` folder on server (same as in windstorms risk assessment)