### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
     - pyogrio=0.8.0
     - pyproj=3.6.1
     - pystac-client=0.8.2
-    - python-kaleido=0.2.1
+    - python-kaleido=0.1.0
     - python=3.12
     - rasterio=1.3.10
     - rasterstats=0.19.0


### PR DESCRIPTION
The river discharge notebooks would hang indefinitely when trying to save the plotly graphs with fig.write_image(). This is fixed by downgrading the python-kaledo to version 0.1.0.