### PR TITLE
Add required version field to CDS request for global sea level change reanalysis data

### DIFF
--- a/01_Coastal_flooding/Hazard_assessment_FLOOD_COASTAL_waterlevel.ipynb
+++ b/01_Coastal_flooding/Hazard_assessment_FLOOD_COASTAL_waterlevel.ipynb
@@ -233,6 +233,7 @@
     "            'temporal_aggregation': ['daily_maximum'],\n",
     "            'year': [year],\n",
     "            'month': ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'],\n",
+    "            \"version\": [\"v3\"],\n",
     "            'format': 'zip',\n",
     "        },\n",
     "        filename)"


### PR DESCRIPTION
After a revision of the dataset, there is now a mandatory `version` field.

https://cds.climate.copernicus.eu/datasets/sis-water-level-change-timeseries-cmip6?tab=download